### PR TITLE
Fix error in string

### DIFF
--- a/commands/dex_commands/learn.js
+++ b/commands/dex_commands/learn.js
@@ -12,7 +12,7 @@ let sourceNames = {
   T:"tutor", 
   X:"egg, traded back", 
   Y:"event, traded back", 
-  V:"VC transfer from gen1"
+  V:"VC transfer from Gen 1/2"
 };
 
 module.exports = {


### PR DESCRIPTION
VC transfers may originate from Generation II games too.