### PR TITLE
changed http protocol to https for image links

### DIFF
--- a/commands/dex_commands/sprite.js
+++ b/commands/dex_commands/sprite.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const http = require('http');
 
-const SPRITE_URL = 'http://play.pokemonshowdown.com/sprites/';
+const SPRITE_URL = 'https://play.pokemonshowdown.com/sprites/';
 
 module.exports = {
   desc: "Image link of a Pokémon, or link to sprite directory if no argument is given. Uses PokemonShowdown's sprite library.",
@@ -37,7 +37,7 @@ module.exports = {
   hasCustomFormatting: true,
   process: async function(msg, flags, dex) {
     if (msg.length === 0){
-      return "```PokemonShowdown's sprite directory:``` http://play.pokemonshowdown.com/sprites/";
+      return "```PokemonShowdown's sprite directory:``` https://play.pokemonshowdown.com/sprites/";
     }
 
     let pokemon = dex.getTemplate(msg[0]);


### PR DESCRIPTION
Sometimes discord will not automatically display images from insecure links. I do not know why. I tested this on other discord channels and sometimes it would show http gifs just fine, but in one of mine I would have to manually edit the link. 